### PR TITLE
Add `alloinit` project initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,23 @@ AlloSphere Research Group
 University of California, Santa Barbara
 
 # Installation
-
-# Using alloinit
-
-The [alloinit](https://github.com/allolib-s22/notes-ethwu/blob/main/alloinit) project provides a simple way to instantiate an allotemplate project. You can easily 
-
-    $ curl https://allolib-s22.github.io/notes-ethwu/alloinit \
-        > ~/.local/bin/alloinit; chmod +x ~/.local/bin/alloinit
-    $ alloinit -N project
-    $ cd project  # project has been created and is ready.
-
-# Manual installation
-
 Allotemplate currently requires:
  * bash shell
  * git
  * cmake version 3.0 or higher
 
-## Creating a new project based on allotemplate
+## Using `alloinit`
+The [`alloinit`](utils/alloinit.md) one-step project initializer can be used to
+initialize a new alloinit project as follows:
+
+```sh
+curl -L https://github.com/Allosphere-Research-Group/allotemplate/raw/master/utils/alloinit \
+    | bash -s proj  # Download `alloinit` and initialize an `allotemplate` project in `proj/`.
+cd proj             # A copy of `alloinit` is now in `proj/utils`.
+./run.sh            # Run your new project!
+```
+
+## Manually creating a new project based on allotemplate
 On a bash shell:
 
     git clone https://github.com/AlloSphere-Research-Group/allotemplate.git <project folder name>

--- a/utils/alloinit
+++ b/utils/alloinit
@@ -1,0 +1,333 @@
+#! /bin/bash
+
+if [ "${BASH_VERSINFO:-0}" -lt 3 ] ; then
+    >&2 echo "$0 requires Bash 3 or greater."
+    exit 1
+fi
+
+# Dependencies needed to run `alloinit`.
+alloinit_deps=( basename find fold git ln mkdir rm rmdir touch tput )
+for dep in "${alloinit_deps[@]}" ; do
+    if ! [[ "$(command -v "$dep")" ]] ; then
+        >&2 echo "$0 requires $dep."
+        exit 1
+    fi
+done
+
+# Propagate non-zero error codes in pipelines.
+set -o pipefail
+
+# Data directory.
+data_home="${XDG_DATA_HOME:-$HOME/.local/share}/alloinit"
+
+# Color support if outputting to a terminal with color.
+if [[ -t 1 ]] && [[ -n "$(tput colors)" ]] && [[ -z ${NO_COLOR+blank} ]] ; then
+    bold="$(tput bold)"
+    underline="$(tput smul)"
+    normal="$(tput sgr0)"
+    red="$(tput setaf 1)"
+    green="$(tput setaf 2)"
+    yellow="$(tput setaf 3)"
+    blue="$(tput setaf 4)"
+fi
+
+# Name of the script.
+name="$(basename $0)"
+# Version.
+version='0.2.0'
+
+# Usage information.
+function show_usage() {
+    local width="$(tput cols)"
+    # Color shortcuts.
+    local n="$normal"
+    local b="$blue"
+    local u="$underline"
+    local g="$green"
+    local y="$yellow"
+    fold -s -w $((width > 80 ? 80 : width)) <<EOF
+$g$0$n $version
+One-step Allolib project initializer.
+
+${y}Usage$n:
+    $g$name <proj>$n                   Start a project in <proj>.
+    $g$name -u <proj>$n                Update Allolib in <proj>.
+
+    $g$name -S [-l <libs>] <proj>$n    Start a project in <proj> using
+                                      shared Allolib in <libs>.
+    $g$name -S [-l <libs>] -r <proj>$n Relink shared Allolib to <proj>.
+    $g$name -S [-l <libs>] -u$n        Update shared Allolib in <libs>.
+    $g$name -S [-l <libs>] -L$n        Install shared Allolib in <libs>.
+
+${y}Options$n:
+    $g-l <libs>$n   Specify the directory where Allolib and its extensions
+                are installed. Defaults to <proj>. In shared mode, defaults to
+                $g\$XDG_DATA_HOME/alloinit/$n. The value of <libs> controls
+                the behavior of $name.
+                [Default: $g<proj>$n or $g$data_home$n]
+    $g-u$n          Update Allolib and its extensions.
+    $g-h$n          Show this help text.
+    $g-V$n          Show the version.
+${y}Shared Mode Options$n:
+    $g-S$n          Operate in shared dependency mode. Projects created in
+                shared dependency mode will use symbolic links to share a
+                user-wide installation of Allolib and its extensions, instead
+                of adding them as submodules to <proj>. In shared mode, <libs>
+                will default to $g\$XDG_DATA_HOME/alloinit/$n instead of the
+                current working directory.
+    $g-r$n          Relink dependencies. Re-creates symbolic links in <proj>
+                so that they point to the shared Allolib in <libs>.
+    $g-L$n          Install Allolib and its extensions in <libs> without
+                creating a project.
+
+${y}Full Documentation$n:
+EOF
+    echo "    $b${u}https://github.com/Allosphere-Research-Group/allotemplate/blob/master/utils/alloinit.md$n"
+}
+
+if [[ $# -lt 1 ]] ; then
+    show_usage
+    exit 0
+fi
+
+# Positional arguments.
+args=()
+# Subcommand to execute.
+subcommand=init
+while [[ $OPTIND -le $# ]] ; do
+    if getopts 'l:ruLShV' opt ; then
+        case "$opt" in
+        l)
+            libs="$OPTARG"
+            ;;
+        r)
+            subcommand=relink
+            ;;
+        u)
+            subcommand=update
+            ;;
+        L)
+            subcommand=installdeps
+            ;;
+        S)
+            shared=1
+            ;;
+        h)
+            show_usage
+            exit 0
+            ;;
+        V)
+            echo "$version"
+            exit 0
+            ;;
+        ?)
+            exit 1
+            ;;
+        esac
+    else
+        # Store positional argument.
+        args+=("${!OPTIND}")
+        ((OPTIND++))
+    fi
+done
+
+# Log a success message to stderr, in bold green if the output is a terminal
+# that supports color.
+function success() { >&2 echo "$bold$green$*$normal" ; }
+# Log an info message to stderr, in blue if the output is a terminal that
+# supports color.
+function info() { >&2 echo "$blue$*$normal" ; }
+# Log a warning message to stderr, in yellow if the output is a terminal that
+# supports color.
+function warn() { >&2 echo "$yellow$*$normal" ; }
+# Log an error message to stderr, in bold red if the output is a terminal that
+# supports color.
+function error() { >&2 echo "$bold$red$*$normal" ; }
+
+# Directory to set up allolib project in.
+dest="${args[0]}"
+# Directory to keep shared dependencies.
+if [[ -n $shared ]] ; then
+    libs="${libs:-$data_home}"
+elif [[ -z "$libs" ]] ; then
+    # Not in shared mode, `libs` defaults to `dest`.
+    libs="$dest"
+fi
+
+if [[ $subcommand =~ (init|relink) ]] && [[ -z "$dest" ]] ||
+    [[ $subcommand = update ]] && [[ -z "$libs" ]] ; then
+    error 'ERROR: Not enough arguments.'
+    >&2 show_usage
+    exit 1
+fi
+
+# Whether the dependency directory already existed before running the script.
+libs_existed="$(test -d "$libs" ; echo $?)"
+# Dependencies shared between allolib projects.
+deps=(
+    allolib
+    al_ext
+)
+
+# Temporary file to indicate that directory was created by alloinit.
+tmpfile=.alloinit.tmp
+
+# Clean up in case of early abort.
+function cleanup() {
+    if [[ $subcommand == init ]] ; then
+        warn 'Could not finish; cleaning up.'
+        for dep in "${deps[@]}" ; do
+            if [[ -f "$libs/.$dep$tmpfile" ]] ; then
+                info "Removing dependency \`$libs/$dep\`."
+                rm -rf "$libs/$dep" "$libs/.$dep$tmpfile"
+            fi
+        done
+
+        # Remove lib if it did not exist prior to running alloinit.
+        if [[ -d "$libs" ]] && ! [[ "$libs_existed" -eq 0 ]] &&
+            [[ -n "$(find "$libs" -maxdepth 0 -type d -empty 2> /dev/null)" ]] ; then
+            rmdir "$libs"
+        fi
+
+        if [[ -f "$dest/$tmpfile" ]] ; then
+            info "Removing project \`$dest\`."
+            rm -rf "$dest"
+        fi
+    fi
+}
+
+function onexit() {
+    [[ $? -gt 0 ]] && cleanup
+
+    [[ $subcommand == init ]] && rm -f "$dest/$tmpfile"
+}
+
+trap onexit EXIT
+
+
+# Install allolib dependencies to $lib.
+function install_dependencies() {
+    mkdir -p "$libs" || exit $?
+    for dep in "${deps[@]}" ; do
+        if [[ ! -d "$libs/$dep" ]] ; then
+            touch "$libs/.$dep$tmpfile" || exit $?
+            info "Retrieving dependency \`$dep\`:"
+            git clone "git@github.com:Allosphere-Research-Group/$dep.git" "$libs/$dep" \
+                --recurse-submodules \
+                --depth 1 \
+                --progress 2>&1 || exit $?
+            rm -f "$libs/.$dep$tmpfile" || exit $?
+        fi
+    done
+}
+
+# Link dependencies to a project. If the first argument is set, also amends the
+# `.gitignore` to ignore the dependency links.
+function link_dependencies() {
+    if [[ -n $shared ]] ; then
+        info 'Linking dependencies.'
+        local write_gitignore=$1
+        [[ -z $write_gitignore ]] || printf "\n\n# allolib dependencies\n" >> "$dest/.gitignore"
+        for dep in "${deps[@]}" ; do
+            if ! [[ -d "$libs/$dep" ]] ; then
+                error "\`$libs/$deps\` is not a directory."
+                exit 1
+            fi
+            loc="$(cd "$libs/$dep" && pwd)" || exit $?
+            [[ -z $write_gitignore ]] || printf "/$dep\n" >> "$dest/.gitignore"
+            info "Linking dependency \`$dep\` to \`$loc\`."
+            ln -sf "$loc" "$dest" || exit $?
+        done
+    fi
+}
+
+# Add dependencies as submodules to a project. Not used when the -s (shared)
+# flag is passed.
+function add_dependencies_as_submodules() (
+    cd "$1"
+    info "Adding dependencies as submodules in \`$1\`."
+    for dep in "${deps[@]}" ; do
+        git submodule add "git@github.com:Allosphere-Research-Group/$dep.git" \
+            2>&1 || exit $?
+    done
+    git submodule update --init --recursive --depth 1 2>&1 || exit $?
+)
+
+# Execute subcommand:
+case $subcommand in
+relink)
+    info "Relinking dependencies in project \`$dest\`."
+    # Install and link dependencies again, but do not write to `.gitignore`.
+    install_dependencies || exit $?
+    link_dependencies || exit $?
+    success "Successfully relinked dependencies in \`$dest\`!"
+    ;;
+update)
+    # Update existing libraries.
+    info "Updating existing Allolib and extensions in \`$libs\`."
+    for dep in "${deps[@]}" ; do
+        if ! [[ -d "$libs/$dep" ]] ; then
+            error "ERROR: \`$dep\` not installed in \`$libs\`."
+            exit 1
+        fi
+        info "Updating dependency \`$dep\`:"
+        (
+            cd "$libs/$dep"
+            # Sync upstream changes to the URL of submodules.
+            git submodule sync --recursive || exit $?
+            # Update submodules.
+            git submodule update --recursive --progress || exit $?
+            # Pull changes.
+            git pull --progress || exit $?
+        ) 2>&1 || exit $?
+    done
+    success "Successfully updated Allolib dependencies in \`$libs\`!"
+    ;;
+installdeps)
+    if ! [[ -n $shared ]] ; then
+        error 'ERROR: Not valid outside of shared mode.'
+        >&2 show_usage
+        exit 1
+    fi
+    info "Installing Allolib and extensions to \`$libs\`"
+    install_dependencies || exit $?
+    success "Successfully installed Allolib dependencies to \`$libs\`!"
+    ;;
+init)
+    if [[ -d "$dest" ]] ; then
+        error "Directory \`$dest\` already exists."
+        exit 1
+    fi
+
+    info "Initializing $([[ -n $shared ]] && echo 'shared ')Allolib project in \`$dest\`:"
+    mkdir -p "$dest" || exit $?
+    # Mark that $dest is currently being initialized. Used for checking whether
+    # to delete it in case of an early exit.
+    touch "$dest/$tmpfile" || exit $?
+    (
+        cd "$dest"
+        # Initialize an empty repository.
+        git init
+        # Pull changes from `allotemplate` as its own remote.
+        git remote add allotemplate git@github.com:Allosphere-Research-Group/allotemplate.git \
+            || exit $?
+        git pull allotemplate master || exit $?
+    ) 2>&1 || exit $?
+
+    # Install dependencies, link them, and write their names to the `.gitignore`.
+    if [[ -n $shared ]] ; then
+        install_dependencies || exit $?
+        link_dependencies write_gitignore || exit $?
+    else
+        add_dependencies_as_submodules "$dest" || exit $?
+    fi
+
+    info 'Configuring allolib project.'
+    (cd "$dest" && ./configure.sh ) 2>&1 || exit $?
+
+    info 'Removing `init.sh`. (No longer needed.)'
+    rm "$dest/"init.sh || exit $?
+
+    success "Successfully initialized Allolib project \`$dest\`!"
+    ;;
+esac

--- a/utils/alloinit.md
+++ b/utils/alloinit.md
@@ -1,0 +1,178 @@
+# `alloinit` ([download][alloinit-download]) #
+
+> One-step [`allotemplate`][allotemplate] initializer.
+
+## Quick Start ##
+
+To start and run a new [`allotemplate`][allotemplate] project:
+
+```sh
+curl -L https://github.com/Allosphere-Research-Group/allotemplate/raw/master/utils/alloinit
+    | bash -s proj  # Download `alloinit` and initialize an `allotemplate` project in `proj/`.
+cd proj             # A copy of `alloinit` is now in `proj/utils`.
+./run.sh            # Run your new project!
+```
+
+To update [Allolib][allolib] and [its extensions][al_ext]:
+
+```sh
+cd proj
+utils/alloinit -u .
+```
+
+## Description ##
+
+`alloinit` ([download][alloinit-download]) is a one-step initializer for
+[`allotemplate`][allotemplate] projects. With one command, `alloinit` can
+generate a fully configured project ready to run:
+
+```sh
+$ alloinit proj   # Set up `allotemplate` project in `proj/`.
+$ cd proj         # Change directories into `proj/`.
+$ ./run.sh        # Run the new project!
+```
+
+Moreover, `alloinit` can share Allolib and its extensions between projects,
+reducing the space utilization on your computer and speeding up the process of
+initializing multiple projects on the same machine (so long as they were all
+created as shared projects):
+
+```sh
+$ # On Computer A:
+$ alloinit -S example-project   # Set up a shared project.
+$ cd example-project
+$ git add . && git commit -m 'Example commit' && git push
+$ ./run.sh                      # Ready to run on Computer A!
+```
+
+```sh
+$ # On Computer B:
+$ git clone git@github.com:username/example-project.git
+$ cd example
+$ alloinit -S -r .              # Link to existing dependencies on Computer B,
+                                # or download them if necessary.
+$ ./run.sh                      # Ready to run on Computer B!
+```
+
+Shared-mode projects are faster to start and clone when using `alloinit`, and
+take up less space than normal projects. However, all shared-mode projects on
+the same machine will share the same versions of Allolib and extensions—which
+may lead to inconsistencies across different machines. Shared mode works by
+using symbolic links instead of Git submodules to link `allolib/` and `al_ext/`
+to a shared location (defaulting to `$XDG_DATA_HOME/alloinit/` or
+`~/.local/share/alloinit/`, but it can be configured by passing `-l <libs>`).
+Specifying different directories with the `-l` flag allows you to have multiple
+shared dependency folders. `alloinit` comes with a set of utilities for managing
+Allolib versions, but because it is all set up with plain symbolic links and
+Git, it can all be managed manually if necessary.
+
+The resulting `allotemplate` project will be a Git repository. You can later
+pull upstream changes from `allotemplate` using the `allotemplate` remote:
+
+```sh
+git pull allotemplate master
+```
+
+## Installation ##
+
+`alloinit` does not need to be installed anywhere if you already have an
+`allotemplate` project. Simply call `alloinit` from the root of the project (the
+one containing the `.git/` directory) using `utils/alloinit` (replace all
+instances of `alloinit` in the examples with `utils/alloinit`).
+
+```sh
+$ ls -AF  # If you are in the root directory, it should look something like this:
+.git/           CMakeLists.txt  al_ext@         bin/            configure.sh*   run.sh*         utils/
+.gitignore      README.md       allolib@        build/          debug.sh*       src/
+$ utils/alloinit -V
+0.2.0
+```
+
+If you would like to access `alloinit` from anywhere or from within scripts,
+download `alloinit` and move it to a directory on your `PATH`. You can download
+`alloinit` from [this link][alloinit-download] or copy it from the `utils/`
+subdirectory of an `allotemplate` project. 
+
+### Adding a directory to `PATH` ###
+
+This example creates a directory `~/.local/bin` and adds it to the `PATH`
+environment variable. On macOS, replace `~/.profile` with `~/.zprofile`.
+
+```sh
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.profile # ~/.zprofile on macOS
+. ~/.profile                                              # ~/.zprofile on macOS
+mkdir -p ~/.local/bin/
+```
+
+### Installing `alloinit` ###
+
+This example downloads `alloinit` and installs it to `~/.local/bin/`, assuming
+that `~/.local/bin/` has been added to the `PATH` environment variable (see
+above).
+
+```sh
+curl -L https://github.com/Allosphere-Research-Group/allotemplate/raw/master/utils/alloinit \
+    > ~/.local/bin/alloinit     # Download `alloinit` to `~/.local/bin/`.
+chmod +x ~/.local/bin/alloinit  # Mark `alloinit` as executable.
+alloinit -h                     # Run `alloinit`!
+```
+
+## Usage ##
+
+### For normal projects ###
+
+Start an [`allotemplate`][allotemplate] project in the directory `proj/`:
+
+```sh
+alloinit proj
+```
+
+Update Allolib and its extensions to the latest versions:
+
+```sh
+alloinit -u proj
+```
+
+### For shared-mode projects ###
+
+> Shared-mode projects offer faster setup times and less space usage at the
+> expense of control over the specific version of Allolib!
+
+Start a shared-mode [`allotemplate`][allotemplate] project in the directory `proj/`:
+
+```sh
+alloinit -S proj
+```
+
+Use the directory `libs/` instead of the default shared dependency directory:
+
+```sh
+alloinit -S -l libs ...
+```
+
+Update the shared Allolib and its extensions to the latest versions:
+
+```sh
+alloinit -S -u
+```
+
+Set up a shared-mode project `proj` on a new computer, or relink the `allolib`
+and `al_ext` symlinks if they were deleted:
+
+```sh
+git clone git@github.com:username/proj.git
+alloinit -S -r proj
+```
+
+Install Allolib and its extensions without creating a new project:
+
+```sh
+alloinit -S -L
+```
+
+[alloinit-download]: https://github.com/Allosphere-Research-Group/allotemplate/raw/master/utils/alloinit
+
+[allolib]: https://github.com/AlloSphere-Research-Group/allolib
+[al_ext]: https://github.com/AlloSphere-Research-Group/al_ext
+[allotemplate]: https://github.com/AlloSphere-Research-Group/allotemplate
+


### PR DESCRIPTION
Add `alloinit` project initializer tool and its documentation to a new `utils/` subdirectory. `alloinit` can be downloaded from the repository in order to generate a new configured `allotemplate` project in one step. It can also share a single pair of `allolib` and `al_ext` modules between several different projects at once, increasing the speed and decreasing the disk usage of starting or cloning multiple `allotemplate` projects at the expense of not pinning the `allolib` and `al_ext` versions.

`alloinit` can also be used to update the `allolib` and `al_ext` versions in both scenarios.